### PR TITLE
Updated sharpness default to 500 and docs

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -145,7 +145,7 @@ class Camera:
         self._hcam_brightness = 16 # Optimal is 16
         self._hcam_gamma = 100
         self._hcam_wbgain = (0, 0, 0)
-        self._hcam_sharpening = 300 # Optimal is 300
+        self._hcam_sharpening = 500 # Optimal is 500
         self._hcam_linear = 0 # Optimal is 0
         self._hcam_curve = 'Polynomial' # Optimal is Polynomial
         self._hcam_image_file_format = 'jpeg'

--- a/camera_configuration.yaml
+++ b/camera_configuration.yaml
@@ -17,7 +17,7 @@ levelrange_low:
 - 0
 linear: 0
 saturation: 128
-sharpening: 300
+sharpening: 500
 temp: 6503
 tint: 1000
 wbgain:

--- a/docs/code.md
+++ b/docs/code.md
@@ -16,7 +16,7 @@ TODO: ADD picture of GUI
 
 ### Camera Options
 
-Pressing the **Advanced Camera Options** button will open a new window that allows the user to adjust camera video and save options. Pressing **Save** will save them to a file called `camera_configuration.yaml` in the directory where the program is located. By default, the program loads the settings from this file on startup. Pressing **Reset** will reset any changes back to this file, or if it is missing, the defaults. The default settings are not optimal, so if the original configuration file is lost, go to [this link](troubleshooting/optimal_settings.md) to get the original file.
+Pressing the **Advanced Camera Options** button will open a new window that allows the user to adjust camera video and save options. Pressing **Save** will save them to a file called `camera_configuration.yaml` in the directory where the program is located. By default, the program loads the settings from this file on startup. Pressing **Reset** will reset any changes back to this file, or if it is missing, the optimal settings. If you need the actual default settings in the API or a copy of the optimal settings file, go to [this link](troubleshooting/optimal_settings.md) to get the original file.
 
 ## Automation 
 * automationScript.py

--- a/docs/troubleshooting/optimal_settings.md
+++ b/docs/troubleshooting/optimal_settings.md
@@ -15,7 +15,7 @@ The camera has a number of defaults for its image settings. However, through tes
 | Brightness             | -64~64    |  0       |  16       |
 | Gamma                  | 20~180    |  100     |  100      |
 | WBGain                 | -127~127 x 3   |  (0,0,0)       |  (0,0,0)       |
-| Sharpening             | 0~500     |  0       |  300      |
+| Sharpening             | 0~500     |  0       |  500      |
 | Linear Tone Mapping    | 1/0       |  1       |  0        |
 | Curved Tone Mapping    | 2/1/0     |  2 (Logarithmic)     |  1 (Polynomial)      |
 
@@ -43,7 +43,7 @@ levelrange_low:
 - 0
 linear: 0
 saturation: 96
-sharpening: 300
+sharpening: 500
 temp: 6503
 tint: 1000
 wbgain:


### PR DESCRIPTION
Updated default sharpness value to new default (500) so that image is as high resolution as possible. I thought the lab wanted it blurrier so that their ring-counting software worked better but it actually works great. I reverted back to highest-resolution. I also updated the documentation to reflect that the optimal settings are now the default instead of the MU500 defaults.