### PR TITLE
A few improvements on May 3rd

### DIFF
--- a/automationScript.py
+++ b/automationScript.py
@@ -46,6 +46,10 @@ class Arduino:
                 raise CriticalIOError("Arduino not connected")
                 return False
             
+        except serial.SerialException as e:
+            print(e)
+            raise CriticalIOError("Port is already open. Please close\nany other instances of the program.")
+
         except Exception as e:
             print("ERROR Could not connect to arduino:")
             raise

--- a/camera.py
+++ b/camera.py
@@ -134,21 +134,21 @@ class Camera:
         @brief Resets the camera's image settings back to default values. To apply changes to the
             camera one must invoke `set_camera_image_settings()` with no arguments.
         """
-        self._hcam_exposure = 50 # Optimal is 50
-        self._hcam_temp = 6503
-        self._hcam_tint = 1000
+        self._hcam_exposure = 120 # Optimal is 120
+        self._hcam_temp = 11616
+        self._hcam_tint = 925
         self._hcam_level_range_low = (0, 0, 0, 0)
         self._hcam_level_range_high = (255, 255, 255, 255)
         self._hcam_contrast = 0
         self._hcam_hue = 0
-        self._hcam_saturation = 96 # Optimal is 96
-        self._hcam_brightness = 16 # Optimal is 16
+        self._hcam_saturation = 126 # Optimal is 126
+        self._hcam_brightness = -64 # Optimal is -64
         self._hcam_gamma = 100
         self._hcam_wbgain = (0, 0, 0)
         self._hcam_sharpening = 500 # Optimal is 500
         self._hcam_linear = 0 # Optimal is 0
         self._hcam_curve = 'Polynomial' # Optimal is Polynomial
-        self._hcam_image_file_format = 'jpeg'
+        self._hcam_image_file_format = 'jpg'
 
     def load_camera_image_settings(self) -> None: # With code borrowed from https://stackoverflow.com/questions/1773805/how-can-i-parse-a-yaml-file-in-python
         try:
@@ -181,6 +181,7 @@ class Camera:
     def get_slider_values(self) -> tuple:
         # if not self.is_microscope(): raise ValueError("Could not load camera settings")
         return (
+            self._hcam_exposure,
             self._hcam_temp,
             self._hcam_tint,
             self._hcam_contrast,

--- a/camera_configuration.yaml
+++ b/camera_configuration.yaml
@@ -1,8 +1,8 @@
-brightness: 16
+brightness: -64
 contrast: 0
 curve: Polynomial
 exposure: 120
-fformat: jpeg
+fformat: jpg
 gamma: 100
 hue: 0
 levelrange_high:
@@ -16,10 +16,10 @@ levelrange_low:
 - 0
 - 0
 linear: 0
-saturation: 128
+saturation: 126
 sharpening: 500
-temp: 6503
-tint: 1000
+temp: 11616
+tint: 925
 wbgain:
 - 0
 - 0

--- a/camera_configuration.yaml
+++ b/camera_configuration.yaml
@@ -1,8 +1,9 @@
+auto_expo: 0
 brightness: -64
 contrast: 0
 curve: Polynomial
 exposure: 120
-fformat: jpg
+fformat: tif
 gamma: 100
 hue: 0
 levelrange_high:

--- a/docs/troubleshooting/optimal_settings.md
+++ b/docs/troubleshooting/optimal_settings.md
@@ -5,6 +5,7 @@ The camera has a number of defaults for its image settings. However, through tes
 
 | Camera Setting         | Range     | Default  | Optimal   |
 | ---------------------- | --------- | -------- | --------- |
+| Auto-Expo Enabled      | 1/0       |  1       |  0        |
 | Auto Exposure Target   |   16~235  |  120     |  120      |
 | Temperature            | 2000~15000|  6503    |  11616    |
 | Tint                   | 200~2500  |  1000    |  925      |
@@ -25,11 +26,12 @@ To configure the camera to the optimal settings, copy the following text block i
 
 **For a Leica KL 1500LCD light:**
 ```yaml
+auto_expo: 0
 brightness: 16
 contrast: 0
 curve: Polynomial
 exposure: 50
-fformat: jpg
+fformat: tiff
 gamma: 100
 hue: 0
 levelrange_high:
@@ -56,11 +58,12 @@ wbgain:
 
 **For a ring light:**
 ```yaml
+auto_expo: 0
 brightness: -64
 contrast: 0
 curve: Polynomial
 exposure: 120
-fformat: jpg
+fformat: tiff
 gamma: 100
 hue: 0
 levelrange_high:

--- a/docs/troubleshooting/optimal_settings.md
+++ b/docs/troubleshooting/optimal_settings.md
@@ -5,14 +5,14 @@ The camera has a number of defaults for its image settings. However, through tes
 
 | Camera Setting         | Range     | Default  | Optimal   |
 | ---------------------- | --------- | -------- | --------- |
-| Auto Exposure Target   |   16~235  |  120     |  50       |
-| Temperature            | 2000~15000|  6503    |  6503     |
-| Tint                   | 200~2500  |  1000    |  1000     |
+| Auto Exposure Target   |   16~235  |  120     |  120      |
+| Temperature            | 2000~15000|  6503    |  11616    |
+| Tint                   | 200~2500  |  1000    |  925      |
 | Level Range            | 0~255 x 4 | L(0,0,0,0) H(255,255,255,255)    | L(0,0,0,0) H(255,255,255,255)   |
 | Contrast               | -100~100  |  0       |  0        |
 | Hue                    | -180~180  |  0       |  0        |
-| Saturation             | 0~255     |  128     |  96       |
-| Brightness             | -64~64    |  0       |  16       |
+| Saturation             | 0~255     |  128     |  126      |
+| Brightness             | -64~64    |  0       |  -64      |
 | Gamma                  | 20~180    |  100     |  100      |
 | WBGain                 | -127~127 x 3   |  (0,0,0)       |  (0,0,0)       |
 | Sharpening             | 0~500     |  0       |  500      |
@@ -23,12 +23,13 @@ The camera has a number of defaults for its image settings. However, through tes
 To configure the camera to the optimal settings, copy the following text block into a file called
 `camera_configuration.yaml` in the directory where the program's exe is in.
 
+**For a Leica KL 1500LCD light:**
 ```yaml
 brightness: 16
 contrast: 0
 curve: Polynomial
 exposure: 50
-fformat: jpeg
+fformat: jpg
 gamma: 100
 hue: 0
 levelrange_high:
@@ -46,6 +47,37 @@ saturation: 96
 sharpening: 500
 temp: 6503
 tint: 1000
+wbgain:
+- 0
+- 0
+- 0
+
+```
+
+**For a ring light:**
+```yaml
+brightness: -64
+contrast: 0
+curve: Polynomial
+exposure: 120
+fformat: jpg
+gamma: 100
+hue: 0
+levelrange_high:
+- 255
+- 255
+- 255
+- 255
+levelrange_low:
+- 0
+- 0
+- 0
+- 0
+linear: 0
+saturation: 126
+sharpening: 500
+temp: 11616
+tint: 925
 wbgain:
 - 0
 - 0

--- a/gui.py
+++ b/gui.py
@@ -31,7 +31,7 @@ class video_stream_thread(QThread):
             if image:
                 scaled_image = image.scaled(640, 480, Qt.KeepAspectRatio)
                 self.change_image.emit(scaled_image)
-            time.sleep(0.0001)  # Required to be slower than camera
+            time.sleep(0.01)  # Required to be slower than camera
 
 class automation_listening_thread(QThread):
     def __init__(self, automation: Automation) -> None:
@@ -512,7 +512,7 @@ class CameraOptionsGUI(QWidget):
         }
     """
 
-        self.setFixedHeight(500)
+        self.setFixedHeight(550)
         self.setFixedWidth(300)
         
         self.initUI()
@@ -537,7 +537,7 @@ class CameraOptionsGUI(QWidget):
         self.sliders_grid.addWidget(self.fformat_label, 0, 0, alignment=Qt.AlignLeft)
 
         self.fformat_dropdown = QComboBox(self)
-        self.fformat_dropdown.addItems(('jpeg', 'tiff', 'png'))
+        self.fformat_dropdown.addItems(('jpg', 'jpeg', 'tif', 'tiff', 'png'))
         self.fformat_dropdown.currentIndexChanged.connect(self.update_fformat_value)
         self.fformat_dropdown.setStyleSheet(
             '''
@@ -554,44 +554,49 @@ class CameraOptionsGUI(QWidget):
         self.temp_slider = Slider(self.update_temp_value, 2000, 15000, 5)
         self.sliders_grid.addWidget(self.temp_slider, 1, 0, alignment=Qt.AlignRight)
 
+        self.expo_label = QLabel('Exposure', self)
+        self.sliders_grid.addWidget(self.expo_label, 2, 0, alignment=Qt.AlignLeft)
+        self.expo_slider = Slider(self.update_expo_value, 16, 235, 1)
+        self.sliders_grid.addWidget(self.expo_slider, 2, 0, alignment=Qt.AlignRight)
+
         self.tint_label = QLabel('Tint', self)
-        self.sliders_grid.addWidget(self.tint_label, 2, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.tint_label, 3, 0, alignment=Qt.AlignLeft)
         self.tint_slider = Slider(self.update_tint_value, 200, 2500, 2)
-        self.sliders_grid.addWidget(self.tint_slider, 2, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.tint_slider, 3, 0, alignment=Qt.AlignRight)
 
         self.contrast_label = QLabel('Contrast', self)
-        self.sliders_grid.addWidget(self.contrast_label, 3, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.contrast_label, 4, 0, alignment=Qt.AlignLeft)
         self.contrast_slider = Slider(self.update_contrast_value, -100, 100, 1)
-        self.sliders_grid.addWidget(self.contrast_slider, 3, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.contrast_slider, 4, 0, alignment=Qt.AlignRight)
 
         self.hue_label = QLabel('Hue', self)
-        self.sliders_grid.addWidget(self.hue_label, 4, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.hue_label, 5, 0, alignment=Qt.AlignLeft)
         self.hue_slider = Slider(self.update_hue_value, -180, 180, 1)
-        self.sliders_grid.addWidget(self.hue_slider, 4, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.hue_slider, 5, 0, alignment=Qt.AlignRight)
 
         self.saturation_label = QLabel('Saturation', self)
-        self.sliders_grid.addWidget(self.saturation_label, 5, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.saturation_label, 6, 0, alignment=Qt.AlignLeft)
         self.saturation_slider = Slider(self.update_saturation_value, 0, 255, 1)
-        self.sliders_grid.addWidget(self.saturation_slider, 5, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.saturation_slider, 6, 0, alignment=Qt.AlignRight)
 
         self.brightness_label = QLabel('Brightness', self)
-        self.sliders_grid.addWidget(self.brightness_label, 6, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.brightness_label, 7, 0, alignment=Qt.AlignLeft)
         self.brightness_slider = Slider(self.update_brightness_value, -64, 64, 1)
-        self.sliders_grid.addWidget(self.brightness_slider, 6, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.brightness_slider, 7, 0, alignment=Qt.AlignRight)
 
         self.sharpening_label = QLabel('Sharpening', self)
-        self.sliders_grid.addWidget(self.sharpening_label, 7, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.sharpening_label, 8, 0, alignment=Qt.AlignLeft)
         self.sharpening_slider = Slider(self.update_sharpening_value, 0, 500, 2)
-        self.sliders_grid.addWidget(self.sharpening_slider, 7, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.sharpening_slider, 8, 0, alignment=Qt.AlignRight)
         
         self.linear_label = QLabel('Linear TM', self)
-        self.sliders_grid.addWidget(self.linear_label, 8, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.linear_label, 9, 0, alignment=Qt.AlignLeft)
         self.linear_cb = QCheckBox(self)
-        self.sliders_grid.addWidget(self.linear_cb, 8, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.linear_cb, 9, 0, alignment=Qt.AlignRight)
         self.linear_cb.stateChanged.connect(self.update_linear_value)
 
         self.curve_label = QLabel('Curve TM', self)
-        self.sliders_grid.addWidget(self.curve_label, 9, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.curve_label, 10, 0, alignment=Qt.AlignLeft)
         self.curve_dropdown = QComboBox(self)
         self.curve_dropdown.addItems(('Off', 'Polynomial', 'Logarithmic'))
         self.curve_dropdown.currentIndexChanged.connect(self.update_curve_value)
@@ -603,7 +608,7 @@ class CameraOptionsGUI(QWidget):
             }
             '''
         )
-        self.sliders_grid.addWidget(self.curve_dropdown, 9, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.curve_dropdown, 10, 0, alignment=Qt.AlignRight)
 
 
         # Create buttons
@@ -625,6 +630,7 @@ class CameraOptionsGUI(QWidget):
         if self.toggled:
             try:
                 (
+                    expo_pos,
                     temp_pos,
                     tint_pos,
                     contrast_pos,
@@ -638,6 +644,7 @@ class CameraOptionsGUI(QWidget):
                 ) = self._camera.get_slider_values()
             except ValueError as e:
                 print(e)
+                expo_pos = 50
                 temp_pos = 6503
                 tint_pos = 1000
                 contrast_pos = 0
@@ -646,11 +653,14 @@ class CameraOptionsGUI(QWidget):
                 brightness_pos = 16
                 sharpening = 500
             if fformat is not None:
-                if fformat == 'jpeg': self.fformat_dropdown.setCurrentIndex(0)
-                elif fformat == 'tiff': self.fformat_dropdown.setCurrentIndex(1)
-                elif fformat == 'png': self.fformat_dropdown.setCurrentIndex(2)
+                if fformat == 'jpg': self.fformat_dropdown.setCurrentIndex(0)
+                if fformat == 'jpeg': self.fformat_dropdown.setCurrentIndex(1)
+                if fformat == 'tif': self.fformat_dropdown.setCurrentIndex(2)
+                elif fformat == 'tiff': self.fformat_dropdown.setCurrentIndex(3)
+                elif fformat == 'png': self.fformat_dropdown.setCurrentIndex(4)
                 else: self.fformat_dropdown.setCurrentIndex(0)
             if temp_pos is not None: self.temp_slider.set_value(temp_pos)
+            if expo_pos is not None: self.expo_slider.set_value(expo_pos)
             if tint_pos is not None: self.tint_slider.set_value(tint_pos)
             if contrast_pos is not None: self.contrast_slider.set_value(contrast_pos)
             if hue_pos is not None: self.hue_slider.set_value(hue_pos)
@@ -668,10 +678,13 @@ class CameraOptionsGUI(QWidget):
 
     def update_fformat_value(self, value: int):
         if not self.toggled: return
-        if value is not None: self._camera.set_camera_image_settings(fformat=('jpeg', 'tiff', 'png')[value])
+        if value is not None: self._camera.set_camera_image_settings(fformat=('jpg', 'jpeg', 'tif', 'tiff', 'png')[value])
     def update_temp_value(self, value: int):
         if not self.toggled: return
         if value is not None: self._camera.set_camera_image_settings(temp=value)
+    def update_expo_value(self, value: int):
+        if not self.toggled: return
+        if value is not None: self._camera.set_camera_image_settings(exposure=value)
     def update_tint_value(self, value: int):
         if not self.toggled: return
         if value is not None: self._camera.set_camera_image_settings(tint=value)
@@ -706,22 +719,6 @@ class CameraOptionsGUI(QWidget):
         self._camera.load_camera_image_settings()
         self._camera.set_camera_image_settings()
         self.load_default_slider_values()
-
-class FileFormatComboBox(QWidget):
-
-    def __init__(self, callback) -> None:
-        super(FileFormatComboBox, self).__init__(None)
-        self.callback = callback
-
-        layout = QHBoxLayout()
-        self.box = QComboBox()
-        self.box.addItems(('png', 'jpg'))
-        self.box.currentIndexChanged.connect(self.callback)
-        layout.addWidget(self.box)
-        self.setLayout(layout)
-    
-    def get_contents(self, idx: int):
-        return self.box.itemData(idx)
 
 
 if __name__ == '__main__':

--- a/gui.py
+++ b/gui.py
@@ -653,13 +653,13 @@ class CameraOptionsGUI(QWidget):
             except ValueError as e:
                 print(e)
                 auto_expo = 0
-                expo_pos = 50
-                temp_pos = 6503
-                tint_pos = 1000
+                expo_pos = 120
+                temp_pos = 11616
+                tint_pos = 925
                 contrast_pos = 0
                 hue_pos = 0
-                sat_pos = 128
-                brightness_pos = 16
+                sat_pos = 126
+                brightness_pos = -64
                 sharpening = 500
             if fformat is not None:
                 if fformat == 'jpg': self.fformat_dropdown.setCurrentIndex(0)

--- a/gui.py
+++ b/gui.py
@@ -533,9 +533,10 @@ class CameraOptionsGUI(QWidget):
         self.grid.addWidget(self.sliders_side, 0, 0, 4, 6)
         self.grid.addWidget(self.buttons_bottom, 4, 0, 1, 6)
 
+        # Various Controls
+
         self.fformat_label = QLabel('File Format', self)
         self.sliders_grid.addWidget(self.fformat_label, 0, 0, alignment=Qt.AlignLeft)
-
         self.fformat_dropdown = QComboBox(self)
         self.fformat_dropdown.addItems(('jpg', 'jpeg', 'tif', 'tiff', 'png'))
         self.fformat_dropdown.currentIndexChanged.connect(self.update_fformat_value)
@@ -549,54 +550,60 @@ class CameraOptionsGUI(QWidget):
         )
         self.sliders_grid.addWidget(self.fformat_dropdown, 0, 0, alignment=Qt.AlignRight)
 
+        self.auto_expo_label = QLabel('Enable Auto Exposure', self)
+        self.sliders_grid.addWidget(self.auto_expo_label, 1, 0, alignment=Qt.AlignLeft)
+        self.auto_expo_cb = QCheckBox(self)
+        self.sliders_grid.addWidget(self.auto_expo_cb, 1, 0, alignment=Qt.AlignRight)
+        self.auto_expo_cb.stateChanged.connect(self.update_auto_expo_value)
+
         self.temp_label = QLabel('Temperature', self)
-        self.sliders_grid.addWidget(self.temp_label, 1, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.temp_label, 2, 0, alignment=Qt.AlignLeft)
         self.temp_slider = Slider(self.update_temp_value, 2000, 15000, 5)
-        self.sliders_grid.addWidget(self.temp_slider, 1, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.temp_slider, 2, 0, alignment=Qt.AlignRight)
 
         self.expo_label = QLabel('Exposure', self)
-        self.sliders_grid.addWidget(self.expo_label, 2, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.expo_label, 3, 0, alignment=Qt.AlignLeft)
         self.expo_slider = Slider(self.update_expo_value, 16, 235, 1)
-        self.sliders_grid.addWidget(self.expo_slider, 2, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.expo_slider, 3, 0, alignment=Qt.AlignRight)
 
         self.tint_label = QLabel('Tint', self)
-        self.sliders_grid.addWidget(self.tint_label, 3, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.tint_label, 4, 0, alignment=Qt.AlignLeft)
         self.tint_slider = Slider(self.update_tint_value, 200, 2500, 2)
-        self.sliders_grid.addWidget(self.tint_slider, 3, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.tint_slider, 4, 0, alignment=Qt.AlignRight)
 
         self.contrast_label = QLabel('Contrast', self)
-        self.sliders_grid.addWidget(self.contrast_label, 4, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.contrast_label, 5, 0, alignment=Qt.AlignLeft)
         self.contrast_slider = Slider(self.update_contrast_value, -100, 100, 1)
-        self.sliders_grid.addWidget(self.contrast_slider, 4, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.contrast_slider, 5, 0, alignment=Qt.AlignRight)
 
         self.hue_label = QLabel('Hue', self)
-        self.sliders_grid.addWidget(self.hue_label, 5, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.hue_label, 6, 0, alignment=Qt.AlignLeft)
         self.hue_slider = Slider(self.update_hue_value, -180, 180, 1)
-        self.sliders_grid.addWidget(self.hue_slider, 5, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.hue_slider, 6, 0, alignment=Qt.AlignRight)
 
         self.saturation_label = QLabel('Saturation', self)
-        self.sliders_grid.addWidget(self.saturation_label, 6, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.saturation_label, 7, 0, alignment=Qt.AlignLeft)
         self.saturation_slider = Slider(self.update_saturation_value, 0, 255, 1)
-        self.sliders_grid.addWidget(self.saturation_slider, 6, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.saturation_slider, 7, 0, alignment=Qt.AlignRight)
 
         self.brightness_label = QLabel('Brightness', self)
-        self.sliders_grid.addWidget(self.brightness_label, 7, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.brightness_label, 8, 0, alignment=Qt.AlignLeft)
         self.brightness_slider = Slider(self.update_brightness_value, -64, 64, 1)
-        self.sliders_grid.addWidget(self.brightness_slider, 7, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.brightness_slider, 8, 0, alignment=Qt.AlignRight)
 
         self.sharpening_label = QLabel('Sharpening', self)
-        self.sliders_grid.addWidget(self.sharpening_label, 8, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.sharpening_label, 9, 0, alignment=Qt.AlignLeft)
         self.sharpening_slider = Slider(self.update_sharpening_value, 0, 500, 2)
-        self.sliders_grid.addWidget(self.sharpening_slider, 8, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.sharpening_slider, 9, 0, alignment=Qt.AlignRight)
         
         self.linear_label = QLabel('Linear TM', self)
-        self.sliders_grid.addWidget(self.linear_label, 9, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.linear_label, 10, 0, alignment=Qt.AlignLeft)
         self.linear_cb = QCheckBox(self)
-        self.sliders_grid.addWidget(self.linear_cb, 9, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.linear_cb, 10, 0, alignment=Qt.AlignRight)
         self.linear_cb.stateChanged.connect(self.update_linear_value)
 
         self.curve_label = QLabel('Curve TM', self)
-        self.sliders_grid.addWidget(self.curve_label, 10, 0, alignment=Qt.AlignLeft)
+        self.sliders_grid.addWidget(self.curve_label, 11, 0, alignment=Qt.AlignLeft)
         self.curve_dropdown = QComboBox(self)
         self.curve_dropdown.addItems(('Off', 'Polynomial', 'Logarithmic'))
         self.curve_dropdown.currentIndexChanged.connect(self.update_curve_value)
@@ -608,7 +615,7 @@ class CameraOptionsGUI(QWidget):
             }
             '''
         )
-        self.sliders_grid.addWidget(self.curve_dropdown, 10, 0, alignment=Qt.AlignRight)
+        self.sliders_grid.addWidget(self.curve_dropdown, 11, 0, alignment=Qt.AlignRight)
 
 
         # Create buttons
@@ -630,6 +637,7 @@ class CameraOptionsGUI(QWidget):
         if self.toggled:
             try:
                 (
+                    auto_expo,
                     expo_pos,
                     temp_pos,
                     tint_pos,
@@ -644,6 +652,7 @@ class CameraOptionsGUI(QWidget):
                 ) = self._camera.get_slider_values()
             except ValueError as e:
                 print(e)
+                auto_expo = 0
                 expo_pos = 50
                 temp_pos = 6503
                 tint_pos = 1000
@@ -659,6 +668,9 @@ class CameraOptionsGUI(QWidget):
                 elif fformat == 'tiff': self.fformat_dropdown.setCurrentIndex(3)
                 elif fformat == 'png': self.fformat_dropdown.setCurrentIndex(4)
                 else: self.fformat_dropdown.setCurrentIndex(0)
+            if auto_expo is not None:
+                if auto_expo == 1: self.auto_expo_cb.setChecked(True)
+                else: self.auto_expo_cb.setChecked(False)
             if temp_pos is not None: self.temp_slider.set_value(temp_pos)
             if expo_pos is not None: self.expo_slider.set_value(expo_pos)
             if tint_pos is not None: self.tint_slider.set_value(tint_pos)
@@ -678,7 +690,11 @@ class CameraOptionsGUI(QWidget):
 
     def update_fformat_value(self, value: int):
         if not self.toggled: return
-        if value is not None: self._camera.set_camera_image_settings(fformat=('jpg', 'jpeg', 'tif', 'tiff', 'png')[value])
+        self._camera.set_camera_image_settings(fformat=('jpg', 'jpeg', 'tif', 'tiff', 'png')[self.fformat_dropdown.currentIndex()])
+    def update_auto_expo_value(self, value: int):
+        if not self.toggled: return
+        if self.auto_expo_cb.isChecked(): self._camera.set_camera_image_settings(auto_expo=1)
+        if not self.auto_expo_cb.isChecked(): self._camera.set_camera_image_settings(auto_expo=0)
     def update_temp_value(self, value: int):
         if not self.toggled: return
         if value is not None: self._camera.set_camera_image_settings(temp=value)
@@ -710,7 +726,7 @@ class CameraOptionsGUI(QWidget):
 
     def update_curve_value(self, value: int):
         if not self.toggled: return
-        if value is not None: self._camera.set_camera_image_settings(curve=('Off', 'Polynomial', 'Logarithmic')[value])
+        self._camera.set_camera_image_settings(curve=('Off', 'Polynomial', 'Logarithmic')[self.curve_dropdown.currentIndex()])
 
     def save_configuration(self) -> None: self._camera.save_camera_settings()
 

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,1 @@
+python ./gui.py

--- a/run.bat
+++ b/run.bat
@@ -1,1 +1,0 @@
-python ./gui.py


### PR DESCRIPTION
Made several updates:
* If another instance of the program is open (using the serial port), an error is shown instead of crashing the second instance.
* Default exposure now set to 120 and an auto exposure target slider is available in the camera options widget.
* Slowed the preview rate to 100 Hz to reduce overall lag.
* Removed a check that prevented users from modifying camera options when a camera other than the microscope is being used (this made sense for the original camera image options but now with the file format option it makes more sense to let the user modify the options at any time)
* Added an auto-exposure enable option that can enable and disable the auto-exposure